### PR TITLE
[WIP] bump libmpv

### DIFF
--- a/com.stremio.Stremio.json
+++ b/com.stremio.Stremio.json
@@ -89,7 +89,7 @@
           ],
           "buildsystem": "simple",
           "build-commands": [
-            "python3 waf configure --prefix=/app --enable-libmpv-shared --disable-cplayer --disable-build-date --disable-alsa ",
+            "python3 waf configure --prefix=/app --disable-manpage-build --enable-libmpv-shared --disable-cplayer --disable-build-date --disable-alsa --disable-pipewire",
             "python3 waf build",
             "python3 waf install"
           ],

--- a/com.stremio.Stremio.json
+++ b/com.stremio.Stremio.json
@@ -96,13 +96,13 @@
           "sources": [
             {
               "type": "archive",
-              "url": "https://github.com/mpv-player/mpv/archive/v0.33.0.tar.gz",
-              "sha256": "f1b9baf5dc2eeaf376597c28a6281facf6ed98ff3d567e3955c95bf2459520b4"
+              "url": "https://github.com/mpv-player/mpv/archive/v0.35.0.tar.gz",
+              "sha256": "dc411c899a64548250c142bf1fa1aa7528f1b4398a24c86b816093999049ec00"
             },
             {
               "type": "file",
-              "url": "https://waf.io/waf-2.0.9",
-              "sha256": "2a8e0816f023995e557f79ea8940d322bec18f286917c8f9a6fa2dc3875dfa48",
+              "url": "https://waf.io/waf-2.0.22",
+              "sha256": "0a09ad26a2cfc69fa26ab871cb558165b60374b5a653ff556a0c6aca63a00df1",
               "dest-filename": "waf"
             }
           ],
@@ -120,7 +120,12 @@
                 {
                   "type": "git",
                   "url": "https://git.videolan.org/git/ffmpeg/nv-codec-headers.git",
-                  "commit": "40e7dd3f646f303e584da1951a4840414a0ace4d"
+                  "tag": "n11.1.5.2",
+                  "commit": "f8ae7a49bfef2f99d2c931a791dc3863fda67bf3",
+                  "x-checker-data": {
+                    "type": "git",
+                    "tag-pattern": "^n([\\d.]+)$"
+                  }
                 }
               ]
             },
@@ -144,8 +149,8 @@
               "sources": [
                 {
                   "type": "archive",
-                  "url": "https://ffmpeg.org/releases/ffmpeg-4.2.2.tar.xz",
-                  "sha256": "cb754255ab0ee2ea5f66f8850e1bd6ad5cac1cd855d0a2f4990fb8c668b0d29c"
+                  "url": "https://ffmpeg.org/releases/ffmpeg-5.1.2.tar.xz",
+                  "sha256": "619e706d662c8420859832ddc259cd4d4096a48a2ce1eefd052db9e440eef3dc"
                 }
               ]
             },
@@ -173,8 +178,8 @@
               "sources": [
                 {
                   "type": "archive",
-                  "url": "https://github.com/libass/libass/releases/download/0.14.0/libass-0.14.0.tar.xz",
-                  "sha256": "881f2382af48aead75b7a0e02e65d88c5ebd369fe46bc77d9270a94aa8fd38a2"
+                  "url": "https://github.com/libass/libass/releases/download/0.15.0/libass-0.15.0.tar.gz",
+                  "sha256": "9cbddee5e8c87e43a5fe627a19cd2aa4c36552156eb4edcf6c5a30bd4934fe58"
                 }
               ]
             },


### PR DESCRIPTION
DO NOT MERGE
This is quite broken, see https://github.com/Stremio/stremio-shell/issues/326 for details


Getting annoyed with some outdated mpv bugs causing stutter on low memory systems. 
so attempting to update it. 
currently broken due to mpv 0.35 trying to connect to pulse first. 
Stremio opens, but playback fails.
Putting this here if anyone feels like assisting. 


bump ffmpeg
bump nv-codec
bump waf
bug WIP libmpv attempting pipewire by default which breaks pulseaudio
bug (preexisting?) vaapi not detected on Intel

Todo: use new meson build for libmpv
* https://github.com/mpv-player/mpv/releases/tag/v0.35.0
* https://github.com/mpv-player/mpv/blob/master/meson_options.txt