### PR TITLE
Add necessary permission for sandbox directory 'stremio-server'

### DIFF
--- a/com.stremio.Stremio.json
+++ b/com.stremio.Stremio.json
@@ -14,6 +14,7 @@
     "--socket=fallback-x11",
     "--socket=wayland",
     "--socket=pulseaudio",
+    "--persist=.stremio-server",
     "--talk-name=org.freedesktop.ScreenSaver",
     "--talk-name=org.freedesktop.Notifications",
     "--talk-name=org.kde.StatusNotifierWatcher",


### PR DESCRIPTION
Without this permission cache and saving settings for streaming server won't work. Closes Stremio/stremio-bugs#386