### PR TITLE
Drop org.kde.* own-name

### DIFF
--- a/com.stremio.Stremio.json
+++ b/com.stremio.Stremio.json
@@ -18,7 +18,6 @@
     "--talk-name=org.freedesktop.ScreenSaver",
     "--talk-name=org.freedesktop.Notifications",
     "--talk-name=org.kde.StatusNotifierWatcher",
-    "--own-name=org.kde.*",
     "--env=TMPDIR=/var/cache/tmp"
   ],
   "cleanup": [


### PR DESCRIPTION
This is no longer required with any supported runtimes, the issue was fixed in Qt

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement

https://github.com/flathub/flatpak-builder-lint/issues/ 66#issuecomment-1386033025