### PR TITLE
Update metainfo to meet Flathub metadata guidelines

### DIFF
--- a/com.stremio.Stremio.metainfo.xml
+++ b/com.stremio.Stremio.metainfo.xml
@@ -3,6 +3,10 @@
   <id>com.stremio.Stremio</id>
   <name>Stremio</name>
   <summary>Freedom to Stream</summary>
+  <branding>
+    <color type="primary" scheme_preference="light">#9d84ff</color>
+    <color type="primary" scheme_preference="dark">#211e45</color>
+  </branding>
   <metadata_license>CC0-1.0</metadata_license>
   <developer id="com.stremio">
     <name>Stremio</name>
@@ -16,8 +20,8 @@
   <project_license>GPL-3.0+</project_license>
   <launchable type="desktop-id">com.stremio.Stremio.desktop</launchable>
   <screenshots>
-    <screenshot height="581" width="691" type="default">
-      <image>https://www.stremio.com/website/desktop-app-mockup.png</image>
+    <screenshot height="878" width="1148" type="default">
+      <image>https://github.com/user-attachments/assets/c94e4d6c-d5fe-4fe7-8fc0-90acbaf93654</image>
       <caption>Discover new content with ease</caption>
     </screenshot>
   </screenshots>


### PR DESCRIPTION
Hello,

I noticed that this app is already quite close to meeting the metadata quality guidelines on Flathub. Complying with these guidelines increases the likelihood of the app being featured in curated sections.

The only remaining issues were the missing brand colors and the screenshot.

Once these changes are visible on the Flathub website, please request a review by logging in with your GitHub account on Flathub, navigating to the Stremio app page, and clicking the review request button.

<img width="1120" height="744" alt="image" src="https://github.com/user-attachments/assets/f6c45318-6c40-494d-89d4-b79c5866e71f" />


<img width="1148" height="878" alt="stremio" src="https://github.com/user-attachments/assets/c94e4d6c-d5fe-4fe7-8fc0-90acbaf93654" />
